### PR TITLE
Updated Schema Model and Baseline to not include system named constraints

### DIFF
--- a/AzureDevOps/AzureDevOps-Flyway-CICD-Pipeline_Linux.yml
+++ b/AzureDevOps/AzureDevOps-Flyway-CICD-Pipeline_Linux.yml
@@ -16,7 +16,7 @@ trigger: none
 ### To Create a Libary Variable Group, Click Pipelines > Library > + Variable Group ###
 # "TARGET_DATABASE_USERNAME"- Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Build Stage Variable Group ###
 
 ### Test Stage Variables - Create 'AutoPilotTest' Variable Group ###
@@ -25,7 +25,7 @@ trigger: none
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_USERNAME" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Test Stage Variable Group ###
 
 ### Prod Stage Variables - Create 'AutoPilotProd' Variable Group ###
@@ -34,7 +34,7 @@ trigger: none
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_USERNAME" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Prod Stage Variable Group ###   
 
 pool:

--- a/AzureDevOps/AzureDevOps-Flyway-CICD-Pipeline_Windows.yml
+++ b/AzureDevOps/AzureDevOps-Flyway-CICD-Pipeline_Windows.yml
@@ -15,7 +15,7 @@ trigger: none
 ### To Create a Libary Variable Group, Click Pipelines > Library > + Variable Group ###
 # "TARGET_DATABASE_USERNAME"- Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Build Stage Variable Group ###
 
 ### Test Stage Variables - Create 'AutoPilotTest' Variable Group ###
@@ -24,7 +24,7 @@ trigger: none
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_USERNAME" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Test Stage Variable Group ###
 
 ### Prod Stage Variables - Create 'AutoPilotProd' Variable Group ###
@@ -33,7 +33,7 @@ trigger: none
 # "TARGET_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_USERNAME" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
 # "REPORT_DATABASE_PASSWORD" - Leave Username/Password values blank if integratedSecurity utilized (Which is default behaviour)
-# CUSTOM_PARAMS: Optional - Used for passing custom Flyway Parameters to each Flyway command
+# "CUSTOM_PARAMS": Optional - Used for passing custom Flyway Parameters to each Flyway command
 ### End of Prod Stage Variable Group ###
 
 pool:

--- a/Scripts/Flyway_DownloadAndInstallCLI.ps1
+++ b/Scripts/Flyway_DownloadAndInstallCLI.ps1
@@ -69,7 +69,7 @@ if ($flywayVersion -ieq "latest") {
 Write-Host "Using Flyway CLI version $flywayVersion"
 
 # Flyway URL to download CLI
-$Url = "https://download.red-gate.com/maven/release/org/flywaydb/enterprise/flyway-commandline/$flywayVersion/flyway-commandline-$flywayVersion-windows-x64.zip"
+$Url = "https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/$flywayVersion/flyway-commandline-$flywayVersion-windows-x64.zip"
 
 # Path for downloaded zip file
 $DownloadZipFile = "$flywayInstallDirectory" + $(Split-Path -Path $Url -Leaf)

--- a/migrations/B001__baseline.sql
+++ b/migrations/B001__baseline.sql
@@ -16,80 +16,6 @@ IF SCHEMA_ID(N'Sales') IS NULL
 EXEC sp_executesql N'CREATE SCHEMA [Sales]
 AUTHORIZATION [dbo]'
 GO
-PRINT N'Creating [Customers].[CustomerFeedback]'
-GO
-CREATE TABLE [Customers].[CustomerFeedback]
-(
-[FeedbackID] [int] NOT NULL IDENTITY(1, 1),
-[CustomerID] [int] NULL,
-[FeedbackDate] [datetime] NULL CONSTRAINT [DF__CustomerF__Feedb__2A4B4B5E] DEFAULT (getdate()),
-[Rating] [int] NULL,
-[Comments] [nvarchar] (500) NULL
-)
-GO
-PRINT N'Creating primary key [PK__Customer__6A4BEDF63E215A69] on [Customers].[CustomerFeedback]'
-GO
-ALTER TABLE [Customers].[CustomerFeedback] ADD CONSTRAINT [PK__Customer__6A4BEDF63E215A69] PRIMARY KEY CLUSTERED ([FeedbackID])
-GO
-PRINT N'Creating [Customers].[LoyaltyProgram]'
-GO
-CREATE TABLE [Customers].[LoyaltyProgram]
-(
-[ProgramID] [int] NOT NULL IDENTITY(1, 1),
-[ProgramName] [nvarchar] (50) NOT NULL,
-[PointsMultiplier] [decimal] (3, 2) NULL CONSTRAINT [DF__LoyaltyPr__Point__267ABA7A] DEFAULT ((1.0))
-)
-GO
-PRINT N'Creating primary key [PK__LoyaltyP__75256038C93BE3A7] on [Customers].[LoyaltyProgram]'
-GO
-ALTER TABLE [Customers].[LoyaltyProgram] ADD CONSTRAINT [PK__LoyaltyP__75256038C93BE3A7] PRIMARY KEY CLUSTERED ([ProgramID])
-GO
-PRINT N'Creating [Inventory].[MaintenanceLog]'
-GO
-CREATE TABLE [Inventory].[MaintenanceLog]
-(
-[LogID] [int] NOT NULL IDENTITY(1, 1),
-[FlightID] [int] NULL,
-[MaintenanceDate] [datetime] NULL CONSTRAINT [DF__Maintenan__Maint__32E0915F] DEFAULT (getdate()),
-[Description] [nvarchar] (500) NULL,
-[MaintenanceStatus] [nvarchar] (20) NULL CONSTRAINT [DF__Maintenan__Maint__33D4B598] DEFAULT ('Pending')
-)
-GO
-PRINT N'Creating primary key [PK__Maintena__5E5499A88B04184F] on [Inventory].[MaintenanceLog]'
-GO
-ALTER TABLE [Inventory].[MaintenanceLog] ADD CONSTRAINT [PK__Maintena__5E5499A88B04184F] PRIMARY KEY CLUSTERED ([LogID])
-GO
-PRINT N'Creating [Sales].[OrderAuditLog]'
-GO
-CREATE TABLE [Sales].[OrderAuditLog]
-(
-[AuditID] [int] NOT NULL IDENTITY(1, 1),
-[OrderID] [int] NULL,
-[ChangeDate] [datetime] NULL CONSTRAINT [DF__OrderAudi__Chang__412EB0B6] DEFAULT (getdate()),
-[ChangeDescription] [nvarchar] (500) NULL
-)
-GO
-PRINT N'Creating primary key [PK__OrderAud__A17F23B8237E8CF2] on [Sales].[OrderAuditLog]'
-GO
-ALTER TABLE [Sales].[OrderAuditLog] ADD CONSTRAINT [PK__OrderAud__A17F23B8237E8CF2] PRIMARY KEY CLUSTERED ([AuditID])
-GO
-PRINT N'Creating [Sales].[Orders]'
-GO
-CREATE TABLE [Sales].[Orders]
-(
-[OrderID] [int] NOT NULL IDENTITY(1, 1),
-[CustomerID] [int] NULL,
-[FlightID] [int] NULL,
-[OrderDate] [datetime] NULL CONSTRAINT [DF__Orders__OrderDat__38996AB5] DEFAULT (getdate()),
-[Status] [nvarchar] (20) NULL CONSTRAINT [DF__Orders__Status__398D8EEE] DEFAULT ('Pending'),
-[TotalAmount] [decimal] (10, 2) NULL,
-[TicketQuantity] [int] NULL
-)
-GO
-PRINT N'Creating primary key [PK__Orders__C3905BAF620C2D5C] on [Sales].[Orders]'
-GO
-ALTER TABLE [Sales].[Orders] ADD CONSTRAINT [PK__Orders__C3905BAF620C2D5C] PRIMARY KEY CLUSTERED ([OrderID])
-GO
 PRINT N'Creating [Customers].[Customer]'
 GO
 CREATE TABLE [Customers].[Customer]
@@ -103,13 +29,28 @@ CREATE TABLE [Customers].[Customer]
 [Address] [nvarchar] (200) NULL
 )
 GO
-PRINT N'Creating primary key [PK__Customer__A4AE64B82992B4E4] on [Customers].[Customer]'
+PRINT N'Creating primary key [PK__Customer__A4AE64B846A6C555] on [Customers].[Customer]'
 GO
-ALTER TABLE [Customers].[Customer] ADD CONSTRAINT [PK__Customer__A4AE64B82992B4E4] PRIMARY KEY CLUSTERED ([CustomerID])
+ALTER TABLE [Customers].[Customer] ADD PRIMARY KEY CLUSTERED ([CustomerID])
 GO
 PRINT N'Adding constraints to [Customers].[Customer]'
 GO
-ALTER TABLE [Customers].[Customer] ADD CONSTRAINT [UQ__Customer__A9D10534B17A14F8] UNIQUE NONCLUSTERED ([Email])
+ALTER TABLE [Customers].[Customer] ADD UNIQUE NONCLUSTERED ([Email])
+GO
+PRINT N'Creating [Customers].[CustomerFeedback]'
+GO
+CREATE TABLE [Customers].[CustomerFeedback]
+(
+[FeedbackID] [int] NOT NULL IDENTITY(1, 1),
+[CustomerID] [int] NULL,
+[FeedbackDate] [datetime] NULL DEFAULT (getdate()),
+[Rating] [int] NULL,
+[Comments] [nvarchar] (500) NULL
+)
+GO
+PRINT N'Creating primary key [PK__Customer__6A4BEDF609D7E6C9] on [Customers].[CustomerFeedback]'
+GO
+ALTER TABLE [Customers].[CustomerFeedback] ADD PRIMARY KEY CLUSTERED ([FeedbackID])
 GO
 PRINT N'Creating [Inventory].[Flight]'
 GO
@@ -125,51 +66,55 @@ CREATE TABLE [Inventory].[Flight]
 [AvailableSeats] [int] NOT NULL
 )
 GO
-PRINT N'Creating primary key [PK__Flight__8A9E148EB937FB76] on [Inventory].[Flight]'
+PRINT N'Creating primary key [PK__Flight__8A9E148E2AC9688E] on [Inventory].[Flight]'
 GO
-ALTER TABLE [Inventory].[Flight] ADD CONSTRAINT [PK__Flight__8A9E148EB937FB76] PRIMARY KEY CLUSTERED ([FlightID])
+ALTER TABLE [Inventory].[Flight] ADD PRIMARY KEY CLUSTERED ([FlightID])
 GO
-PRINT N'Creating [Customers].[RecordFeedback]'
+PRINT N'Creating [Inventory].[MaintenanceLog]'
 GO
-
-CREATE PROCEDURE [Customers].[RecordFeedback]
-    @CustomerID INT,
-    @Rating INT,
-    @Comments NVARCHAR(500)
-AS
-BEGIN
-    INSERT INTO Customers.CustomerFeedback (CustomerID, Rating, Comments)
-    VALUES (@CustomerID, @Rating, @Comments);
-
-    PRINT 'Customer feedback recorded successfully.';
-END;
+CREATE TABLE [Inventory].[MaintenanceLog]
+(
+[LogID] [int] NOT NULL IDENTITY(1, 1),
+[FlightID] [int] NULL,
+[MaintenanceDate] [datetime] NULL DEFAULT (getdate()),
+[Description] [nvarchar] (500) NULL,
+[MaintenanceStatus] [nvarchar] (20) NULL DEFAULT ('Pending')
+)
 GO
-PRINT N'Creating [Inventory].[AddMaintenanceLog]'
+PRINT N'Creating primary key [PK__Maintena__5E5499A88C8D751D] on [Inventory].[MaintenanceLog]'
 GO
-
-CREATE PROCEDURE [Inventory].[AddMaintenanceLog]
-    @FlightID INT,
-    @Description NVARCHAR(500)
-AS
-BEGIN
-    INSERT INTO Inventory.MaintenanceLog (FlightID, Description, MaintenanceStatus)
-    VALUES (@FlightID, @Description, 'Pending');
-
-    PRINT 'Maintenance log entry created.';
-END;
+ALTER TABLE [Inventory].[MaintenanceLog] ADD PRIMARY KEY CLUSTERED ([LogID])
 GO
-PRINT N'Creating [Inventory].[UpdateAvailableSeats]'
+PRINT N'Creating [Sales].[Orders]'
 GO
-
-CREATE PROCEDURE [Inventory].[UpdateAvailableSeats]
-    @FlightID INT,
-    @SeatChange INT
-AS
-BEGIN
-    UPDATE Inventory.Flight
-    SET AvailableSeats = AvailableSeats + @SeatChange
-    WHERE FlightID = @FlightID;
-END;
+CREATE TABLE [Sales].[Orders]
+(
+[OrderID] [int] NOT NULL IDENTITY(1, 1),
+[CustomerID] [int] NULL,
+[FlightID] [int] NULL,
+[OrderDate] [datetime] NULL DEFAULT (getdate()),
+[Status] [nvarchar] (20) NULL DEFAULT ('Pending'),
+[TotalAmount] [decimal] (10, 2) NULL,
+[TicketQuantity] [int] NULL
+)
+GO
+PRINT N'Creating primary key [PK__Orders__C3905BAFA1ACF1EC] on [Sales].[Orders]'
+GO
+ALTER TABLE [Sales].[Orders] ADD PRIMARY KEY CLUSTERED ([OrderID])
+GO
+PRINT N'Creating [Sales].[OrderAuditLog]'
+GO
+CREATE TABLE [Sales].[OrderAuditLog]
+(
+[AuditID] [int] NOT NULL IDENTITY(1, 1),
+[OrderID] [int] NULL,
+[ChangeDate] [datetime] NULL DEFAULT (getdate()),
+[ChangeDescription] [nvarchar] (500) NULL
+)
+GO
+PRINT N'Creating primary key [PK__OrderAud__A17F23B8A57D954B] on [Sales].[OrderAuditLog]'
+GO
+ALTER TABLE [Sales].[OrderAuditLog] ADD PRIMARY KEY CLUSTERED ([AuditID])
 GO
 PRINT N'Creating [Sales].[DiscountCode]'
 GO
@@ -181,45 +126,56 @@ CREATE TABLE [Sales].[DiscountCode]
 [ExpiryDate] [datetime] NULL
 )
 GO
-PRINT N'Creating primary key [PK__Discount__E43F6DF6AB26F780] on [Sales].[DiscountCode]'
+PRINT N'Creating primary key [PK__Discount__E43F6DF68E529EAA] on [Sales].[DiscountCode]'
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [PK__Discount__E43F6DF6AB26F780] PRIMARY KEY CLUSTERED ([DiscountID])
+ALTER TABLE [Sales].[DiscountCode] ADD PRIMARY KEY CLUSTERED ([DiscountID])
 GO
 PRINT N'Adding constraints to [Sales].[DiscountCode]'
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [UQ__Discount__A25C5AA7D45A51FC] UNIQUE NONCLUSTERED ([Code])
+ALTER TABLE [Sales].[DiscountCode] ADD UNIQUE NONCLUSTERED ([Code])
 GO
-PRINT N'Creating [Sales].[ApplyDiscount]'
+PRINT N'Creating [Sales].[CustomerOrdersView]'
+GO
+CREATE VIEW [Sales].[CustomerOrdersView] AS
+SELECT 
+    c.CustomerID,
+    c.FirstName,
+    c.LastName,
+    o.OrderID,
+    o.OrderDate,
+    o.Status,
+    o.TotalAmount
+FROM Customers.Customer c
+JOIN Sales.Orders o ON c.CustomerID = o.CustomerID;
+GO
+PRINT N'Creating [Customers].[CustomerFeedbackSummary]'
 GO
 
-CREATE PROCEDURE [Sales].[ApplyDiscount]
-    @OrderID INT,
-    @DiscountCode NVARCHAR(20)
-AS
-BEGIN
-    DECLARE @DiscountID INT, @DiscountPercentage DECIMAL(4, 2), @ExpiryDate DATETIME;
-    
-    SELECT 
-        @DiscountID = DiscountID,
-        @DiscountPercentage = DiscountPercentage,
-        @ExpiryDate = ExpiryDate
-    FROM Sales.DiscountCode
-    WHERE Code = @DiscountCode;
-    
-    IF @DiscountID IS NOT NULL AND @ExpiryDate >= GETDATE()
-    BEGIN
-        UPDATE Sales.Orders
-        SET TotalAmount = TotalAmount * (1 - @DiscountPercentage / 100)
-        WHERE OrderID = @OrderID;
+CREATE VIEW [Customers].[CustomerFeedbackSummary] AS
+SELECT 
+    c.CustomerID,
+    c.FirstName,
+    c.LastName,
+    AVG(f.Rating) AS AverageRating,
+    COUNT(f.FeedbackID) AS FeedbackCount
+FROM Customers.Customer c
+LEFT JOIN Customers.CustomerFeedback f ON c.CustomerID = f.CustomerID
+GROUP BY c.CustomerID, c.FirstName, c.LastName;
+GO
+PRINT N'Creating [Inventory].[FlightMaintenanceStatus]'
+GO
 
-        INSERT INTO Sales.OrderAuditLog (OrderID, ChangeDescription)
-        VALUES (@OrderID, CONCAT('Discount ', @DiscountCode, ' applied with ', @DiscountPercentage, '% off.'));
-    END
-    ELSE
-    BEGIN
-        RAISERROR('Invalid or expired discount code.', 16, 1);
-    END
-END;
+CREATE VIEW [Inventory].[FlightMaintenanceStatus] AS
+SELECT 
+    f.FlightID,
+    f.Airline,
+    f.DepartureCity,
+    f.ArrivalCity,
+    COUNT(m.LogID) AS MaintenanceCount,
+    SUM(CASE WHEN m.MaintenanceStatus = 'Completed' THEN 1 ELSE 0 END) AS CompletedMaintenance
+FROM Inventory.Flight f
+LEFT JOIN Inventory.MaintenanceLog m ON f.FlightID = m.FlightID
+GROUP BY f.FlightID, f.Airline, f.DepartureCity, f.ArrivalCity;
 GO
 PRINT N'Creating [Sales].[GetCustomerFlightHistory]'
 GO
@@ -256,48 +212,92 @@ BEGIN
     WHERE OrderID = @OrderID;
 END;
 GO
-PRINT N'Creating [Customers].[CustomerFeedbackSummary]'
+PRINT N'Creating [Inventory].[UpdateAvailableSeats]'
 GO
 
-CREATE VIEW [Customers].[CustomerFeedbackSummary] AS
-SELECT 
-    c.CustomerID,
-    c.FirstName,
-    c.LastName,
-    AVG(f.Rating) AS AverageRating,
-    COUNT(f.FeedbackID) AS FeedbackCount
-FROM Customers.Customer c
-LEFT JOIN Customers.CustomerFeedback f ON c.CustomerID = f.CustomerID
-GROUP BY c.CustomerID, c.FirstName, c.LastName;
+CREATE PROCEDURE [Inventory].[UpdateAvailableSeats]
+    @FlightID INT,
+    @SeatChange INT
+AS
+BEGIN
+    UPDATE Inventory.Flight
+    SET AvailableSeats = AvailableSeats + @SeatChange
+    WHERE FlightID = @FlightID;
+END;
 GO
-PRINT N'Creating [Inventory].[FlightMaintenanceStatus]'
+PRINT N'Creating [Sales].[ApplyDiscount]'
 GO
 
-CREATE VIEW [Inventory].[FlightMaintenanceStatus] AS
-SELECT 
-    f.FlightID,
-    f.Airline,
-    f.DepartureCity,
-    f.ArrivalCity,
-    COUNT(m.LogID) AS MaintenanceCount,
-    SUM(CASE WHEN m.MaintenanceStatus = 'Completed' THEN 1 ELSE 0 END) AS CompletedMaintenance
-FROM Inventory.Flight f
-LEFT JOIN Inventory.MaintenanceLog m ON f.FlightID = m.FlightID
-GROUP BY f.FlightID, f.Airline, f.DepartureCity, f.ArrivalCity;
+CREATE PROCEDURE [Sales].[ApplyDiscount]
+    @OrderID INT,
+    @DiscountCode NVARCHAR(20)
+AS
+BEGIN
+    DECLARE @DiscountID INT, @DiscountPercentage DECIMAL(4, 2), @ExpiryDate DATETIME;
+    
+    SELECT 
+        @DiscountID = DiscountID,
+        @DiscountPercentage = DiscountPercentage,
+        @ExpiryDate = ExpiryDate
+    FROM Sales.DiscountCode
+    WHERE Code = @DiscountCode;
+    
+    IF @DiscountID IS NOT NULL AND @ExpiryDate >= GETDATE()
+    BEGIN
+        UPDATE Sales.Orders
+        SET TotalAmount = TotalAmount * (1 - @DiscountPercentage / 100)
+        WHERE OrderID = @OrderID;
+
+        INSERT INTO Sales.OrderAuditLog (OrderID, ChangeDescription)
+        VALUES (@OrderID, CONCAT('Discount ', @DiscountCode, ' applied with ', @DiscountPercentage, '% off.'));
+    END
+    ELSE
+    BEGIN
+        RAISERROR('Invalid or expired discount code.', 16, 1);
+    END
+END;
 GO
-PRINT N'Creating [Sales].[CustomerOrdersView]'
+PRINT N'Creating [Inventory].[AddMaintenanceLog]'
 GO
-CREATE VIEW [Sales].[CustomerOrdersView] AS
-SELECT 
-    c.CustomerID,
-    c.FirstName,
-    c.LastName,
-    o.OrderID,
-    o.OrderDate,
-    o.Status,
-    o.TotalAmount
-FROM Customers.Customer c
-JOIN Sales.Orders o ON c.CustomerID = o.CustomerID;
+
+CREATE PROCEDURE [Inventory].[AddMaintenanceLog]
+    @FlightID INT,
+    @Description NVARCHAR(500)
+AS
+BEGIN
+    INSERT INTO Inventory.MaintenanceLog (FlightID, Description, MaintenanceStatus)
+    VALUES (@FlightID, @Description, 'Pending');
+
+    PRINT 'Maintenance log entry created.';
+END;
+GO
+PRINT N'Creating [Customers].[RecordFeedback]'
+GO
+
+CREATE PROCEDURE [Customers].[RecordFeedback]
+    @CustomerID INT,
+    @Rating INT,
+    @Comments NVARCHAR(500)
+AS
+BEGIN
+    INSERT INTO Customers.CustomerFeedback (CustomerID, Rating, Comments)
+    VALUES (@CustomerID, @Rating, @Comments);
+
+    PRINT 'Customer feedback recorded successfully.';
+END;
+GO
+PRINT N'Creating [Customers].[LoyaltyProgram]'
+GO
+CREATE TABLE [Customers].[LoyaltyProgram]
+(
+[ProgramID] [int] NOT NULL IDENTITY(1, 1),
+[ProgramName] [nvarchar] (50) NOT NULL,
+[PointsMultiplier] [decimal] (3, 2) NULL DEFAULT ((1.0))
+)
+GO
+PRINT N'Creating primary key [PK__LoyaltyP__752560385D8B3B1E] on [Customers].[LoyaltyProgram]'
+GO
+ALTER TABLE [Customers].[LoyaltyProgram] ADD PRIMARY KEY CLUSTERED ([ProgramID])
 GO
 PRINT N'Creating [Inventory].[FlightRoute]'
 GO
@@ -309,17 +309,17 @@ CREATE TABLE [Inventory].[FlightRoute]
 [Distance] [int] NOT NULL
 )
 GO
-PRINT N'Creating primary key [PK__FlightRo__80979AAD7FA082B5] on [Inventory].[FlightRoute]'
+PRINT N'Creating primary key [PK__FlightRo__80979AAD7FAB3A8D] on [Inventory].[FlightRoute]'
 GO
-ALTER TABLE [Inventory].[FlightRoute] ADD CONSTRAINT [PK__FlightRo__80979AAD7FA082B5] PRIMARY KEY CLUSTERED ([RouteID])
+ALTER TABLE [Inventory].[FlightRoute] ADD PRIMARY KEY CLUSTERED ([RouteID])
 GO
 PRINT N'Adding constraints to [Customers].[CustomerFeedback]'
 GO
-ALTER TABLE [Customers].[CustomerFeedback] ADD CONSTRAINT [CK__CustomerF__Ratin__2B3F6F97] CHECK (([Rating]>=(1) AND [Rating]<=(5)))
+ALTER TABLE [Customers].[CustomerFeedback] ADD CHECK (([Rating]>=(1) AND [Rating]<=(5)))
 GO
 PRINT N'Adding constraints to [Sales].[DiscountCode]'
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [CK__DiscountC__Disco__3D5E1FD2] CHECK (([DiscountPercentage]>=(0) AND [DiscountPercentage]<=(100)))
+ALTER TABLE [Sales].[DiscountCode] ADD CHECK (([DiscountPercentage]>=(0) AND [DiscountPercentage]<=(100)))
 GO
 PRINT N'Adding foreign keys to [Customers].[CustomerFeedback]'
 GO

--- a/schema-model/RedGateDatabaseInfo.xml
+++ b/schema-model/RedGateDatabaseInfo.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <DatabaseInformation Version="3">
   <ScriptFileEncoding>UTF8</ScriptFileEncoding>
+  <DefaultCollation>Latin1_General_CI_AS</DefaultCollation>
   <DefaultSchema>dbo</DefaultSchema>
   <DefaultUser>dbo</DefaultUser>
   <DefaultFilegroup>PRIMARY</DefaultFilegroup>
@@ -63,7 +64,6 @@
     </Prefixes>
     <DataWriteAllFilesInOneDirectory>True</DataWriteAllFilesInOneDirectory>
   </WriteToFileOptions>
-  <DefaultCollation>Latin1_General_CI_AS</DefaultCollation>
   <DataFileSet>
     <Count>0</Count>
   </DataFileSet>

--- a/schema-model/Tables/Customers.Customer.sql
+++ b/schema-model/Tables/Customers.Customer.sql
@@ -9,7 +9,7 @@ CREATE TABLE [Customers].[Customer]
 [Address] [nvarchar] (200) NULL
 )
 GO
-ALTER TABLE [Customers].[Customer] ADD CONSTRAINT [PK__Customer__A4AE64B82992B4E4] PRIMARY KEY CLUSTERED ([CustomerID])
+ALTER TABLE [Customers].[Customer] ADD PRIMARY KEY CLUSTERED ([CustomerID])
 GO
-ALTER TABLE [Customers].[Customer] ADD CONSTRAINT [UQ__Customer__A9D10534B17A14F8] UNIQUE NONCLUSTERED ([Email])
+ALTER TABLE [Customers].[Customer] ADD UNIQUE NONCLUSTERED ([Email])
 GO

--- a/schema-model/Tables/Customers.CustomerFeedback.sql
+++ b/schema-model/Tables/Customers.CustomerFeedback.sql
@@ -2,14 +2,14 @@ CREATE TABLE [Customers].[CustomerFeedback]
 (
 [FeedbackID] [int] NOT NULL IDENTITY(1, 1),
 [CustomerID] [int] NULL,
-[FeedbackDate] [datetime] NULL CONSTRAINT [DF__CustomerF__Feedb__2A4B4B5E] DEFAULT (getdate()),
+[FeedbackDate] [datetime] NULL DEFAULT (getdate()),
 [Rating] [int] NULL,
 [Comments] [nvarchar] (500) NULL
 )
 GO
-ALTER TABLE [Customers].[CustomerFeedback] ADD CONSTRAINT [CK__CustomerF__Ratin__2B3F6F97] CHECK (([Rating]>=(1) AND [Rating]<=(5)))
+ALTER TABLE [Customers].[CustomerFeedback] ADD CHECK (([Rating]>=(1) AND [Rating]<=(5)))
 GO
-ALTER TABLE [Customers].[CustomerFeedback] ADD CONSTRAINT [PK__Customer__6A4BEDF63E215A69] PRIMARY KEY CLUSTERED ([FeedbackID])
+ALTER TABLE [Customers].[CustomerFeedback] ADD PRIMARY KEY CLUSTERED ([FeedbackID])
 GO
-ALTER TABLE [Customers].[CustomerFeedback] ADD CONSTRAINT [FK__CustomerF__Custo__29572725] FOREIGN KEY ([CustomerID]) REFERENCES [Customers].[Customer] ([CustomerID])
+ALTER TABLE [Customers].[CustomerFeedback] ADD FOREIGN KEY ([CustomerID]) REFERENCES [Customers].[Customer] ([CustomerID])
 GO

--- a/schema-model/Tables/Customers.LoyaltyProgram.sql
+++ b/schema-model/Tables/Customers.LoyaltyProgram.sql
@@ -2,8 +2,8 @@ CREATE TABLE [Customers].[LoyaltyProgram]
 (
 [ProgramID] [int] NOT NULL IDENTITY(1, 1),
 [ProgramName] [nvarchar] (50) NOT NULL,
-[PointsMultiplier] [decimal] (3, 2) NULL CONSTRAINT [DF__LoyaltyPr__Point__267ABA7A] DEFAULT ((1.0))
+[PointsMultiplier] [decimal] (3, 2) NULL DEFAULT ((1.0))
 )
 GO
-ALTER TABLE [Customers].[LoyaltyProgram] ADD CONSTRAINT [PK__LoyaltyP__75256038C93BE3A7] PRIMARY KEY CLUSTERED ([ProgramID])
+ALTER TABLE [Customers].[LoyaltyProgram] ADD PRIMARY KEY CLUSTERED ([ProgramID])
 GO

--- a/schema-model/Tables/Inventory.Flight.sql
+++ b/schema-model/Tables/Inventory.Flight.sql
@@ -10,5 +10,5 @@ CREATE TABLE [Inventory].[Flight]
 [AvailableSeats] [int] NOT NULL
 )
 GO
-ALTER TABLE [Inventory].[Flight] ADD CONSTRAINT [PK__Flight__8A9E148EB937FB76] PRIMARY KEY CLUSTERED ([FlightID])
+ALTER TABLE [Inventory].[Flight] ADD PRIMARY KEY CLUSTERED ([FlightID])
 GO

--- a/schema-model/Tables/Inventory.FlightRoute.sql
+++ b/schema-model/Tables/Inventory.FlightRoute.sql
@@ -6,5 +6,5 @@ CREATE TABLE [Inventory].[FlightRoute]
 [Distance] [int] NOT NULL
 )
 GO
-ALTER TABLE [Inventory].[FlightRoute] ADD CONSTRAINT [PK__FlightRo__80979AAD7FA082B5] PRIMARY KEY CLUSTERED ([RouteID])
+ALTER TABLE [Inventory].[FlightRoute] ADD PRIMARY KEY CLUSTERED ([RouteID])
 GO

--- a/schema-model/Tables/Inventory.MaintenanceLog.sql
+++ b/schema-model/Tables/Inventory.MaintenanceLog.sql
@@ -2,12 +2,12 @@ CREATE TABLE [Inventory].[MaintenanceLog]
 (
 [LogID] [int] NOT NULL IDENTITY(1, 1),
 [FlightID] [int] NULL,
-[MaintenanceDate] [datetime] NULL CONSTRAINT [DF__Maintenan__Maint__32E0915F] DEFAULT (getdate()),
+[MaintenanceDate] [datetime] NULL DEFAULT (getdate()),
 [Description] [nvarchar] (500) NULL,
-[MaintenanceStatus] [nvarchar] (20) NULL CONSTRAINT [DF__Maintenan__Maint__33D4B598] DEFAULT ('Pending')
+[MaintenanceStatus] [nvarchar] (20) NULL DEFAULT ('Pending')
 )
 GO
-ALTER TABLE [Inventory].[MaintenanceLog] ADD CONSTRAINT [PK__Maintena__5E5499A88B04184F] PRIMARY KEY CLUSTERED ([LogID])
+ALTER TABLE [Inventory].[MaintenanceLog] ADD PRIMARY KEY CLUSTERED ([LogID])
 GO
-ALTER TABLE [Inventory].[MaintenanceLog] ADD CONSTRAINT [FK__Maintenan__Fligh__31EC6D26] FOREIGN KEY ([FlightID]) REFERENCES [Inventory].[Flight] ([FlightID])
+ALTER TABLE [Inventory].[MaintenanceLog] ADD FOREIGN KEY ([FlightID]) REFERENCES [Inventory].[Flight] ([FlightID])
 GO

--- a/schema-model/Tables/Sales.DiscountCode.sql
+++ b/schema-model/Tables/Sales.DiscountCode.sql
@@ -6,9 +6,9 @@ CREATE TABLE [Sales].[DiscountCode]
 [ExpiryDate] [datetime] NULL
 )
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [CK__DiscountC__Disco__3D5E1FD2] CHECK (([DiscountPercentage]>=(0) AND [DiscountPercentage]<=(100)))
+ALTER TABLE [Sales].[DiscountCode] ADD CHECK (([DiscountPercentage]>=(0) AND [DiscountPercentage]<=(100)))
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [PK__Discount__E43F6DF6AB26F780] PRIMARY KEY CLUSTERED ([DiscountID])
+ALTER TABLE [Sales].[DiscountCode] ADD PRIMARY KEY CLUSTERED ([DiscountID])
 GO
-ALTER TABLE [Sales].[DiscountCode] ADD CONSTRAINT [UQ__Discount__A25C5AA7D45A51FC] UNIQUE NONCLUSTERED ([Code])
+ALTER TABLE [Sales].[DiscountCode] ADD UNIQUE NONCLUSTERED ([Code])
 GO

--- a/schema-model/Tables/Sales.OrderAuditLog.sql
+++ b/schema-model/Tables/Sales.OrderAuditLog.sql
@@ -2,11 +2,11 @@ CREATE TABLE [Sales].[OrderAuditLog]
 (
 [AuditID] [int] NOT NULL IDENTITY(1, 1),
 [OrderID] [int] NULL,
-[ChangeDate] [datetime] NULL CONSTRAINT [DF__OrderAudi__Chang__412EB0B6] DEFAULT (getdate()),
+[ChangeDate] [datetime] NULL DEFAULT (getdate()),
 [ChangeDescription] [nvarchar] (500) NULL
 )
 GO
-ALTER TABLE [Sales].[OrderAuditLog] ADD CONSTRAINT [PK__OrderAud__A17F23B8237E8CF2] PRIMARY KEY CLUSTERED ([AuditID])
+ALTER TABLE [Sales].[OrderAuditLog] ADD PRIMARY KEY CLUSTERED ([AuditID])
 GO
-ALTER TABLE [Sales].[OrderAuditLog] ADD CONSTRAINT [FK__OrderAudi__Order__403A8C7D] FOREIGN KEY ([OrderID]) REFERENCES [Sales].[Orders] ([OrderID])
+ALTER TABLE [Sales].[OrderAuditLog] ADD FOREIGN KEY ([OrderID]) REFERENCES [Sales].[Orders] ([OrderID])
 GO

--- a/schema-model/Tables/Sales.Orders.sql
+++ b/schema-model/Tables/Sales.Orders.sql
@@ -3,15 +3,15 @@ CREATE TABLE [Sales].[Orders]
 [OrderID] [int] NOT NULL IDENTITY(1, 1),
 [CustomerID] [int] NULL,
 [FlightID] [int] NULL,
-[OrderDate] [datetime] NULL CONSTRAINT [DF__Orders__OrderDat__38996AB5] DEFAULT (getdate()),
-[Status] [nvarchar] (20) NULL CONSTRAINT [DF__Orders__Status__398D8EEE] DEFAULT ('Pending'),
+[OrderDate] [datetime] NULL DEFAULT (getdate()),
+[Status] [nvarchar] (20) NULL DEFAULT ('Pending'),
 [TotalAmount] [decimal] (10, 2) NULL,
 [TicketQuantity] [int] NULL
 )
 GO
-ALTER TABLE [Sales].[Orders] ADD CONSTRAINT [PK__Orders__C3905BAF620C2D5C] PRIMARY KEY CLUSTERED ([OrderID])
+ALTER TABLE [Sales].[Orders] ADD PRIMARY KEY CLUSTERED ([OrderID])
 GO
-ALTER TABLE [Sales].[Orders] ADD CONSTRAINT [FK__Orders__Customer__36B12243] FOREIGN KEY ([CustomerID]) REFERENCES [Customers].[Customer] ([CustomerID])
+ALTER TABLE [Sales].[Orders] ADD FOREIGN KEY ([CustomerID]) REFERENCES [Customers].[Customer] ([CustomerID])
 GO
-ALTER TABLE [Sales].[Orders] ADD CONSTRAINT [FK__Orders__FlightID__37A5467C] FOREIGN KEY ([FlightID]) REFERENCES [Inventory].[Flight] ([FlightID])
+ALTER TABLE [Sales].[Orders] ADD FOREIGN KEY ([FlightID]) REFERENCES [Inventory].[Flight] ([FlightID])
 GO


### PR DESCRIPTION
In this PR - All Schema Model Files and Baseline script has been updated to no longer include system named constraints by default. This can be reenabled where required.