### PR TITLE
Fixed broken flyway download and install

### DIFF
--- a/Scripts/Flyway_DownloadAndInstallCLI.ps1
+++ b/Scripts/Flyway_DownloadAndInstallCLI.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-# Flyway Version to Use (Check for latest version: https://documentation.red-gate.com/fd/command-line-184127404.html)
+# Flyway Version to Use (Check for latest version: https://documentation.red-gate.com/flyway/reference/usage/command-line.html)
 if ($null -ne ${env:FLYWAY_VERSION}) {
   # Environment Variables - Use these if set as a variable - Target Database Connection Details
   Write-Output "Using Environment Variables for Flyway CLI Version Number"
@@ -35,13 +35,13 @@ if ($null -ne ${env:FLYWAY_PATH_LOCATION}) {
 }
 
 # Fetch the content of the web page
-Write-Output "Analysing https://documentation.red-gate.com/fd/command-line-277579359.html for Latest Version Number"
+Write-Output "Analysing https://documentation.red-gate.com/flyway/reference/usage/command-line.html for Latest Version Number"
 # Check if $flywayVersion is 'latest' (case-insensitive)
 if ($flywayVersion -ieq "latest") {
     # Fetch the content of the web page
     try {
         # Define the URL to fetch and fetch page content
-        $url = "https://documentation.red-gate.com/fd/command-line-277579359.html"
+        $url = "https://documentation.red-gate.com/flyway/reference/usage/command-line.html"
         $response = Invoke-WebRequest -Uri $url -UseBasicParsing
         $content = $response.Content
 

--- a/Scripts/Flyway_DownloadAndInstallCLI.ps1
+++ b/Scripts/Flyway_DownloadAndInstallCLI.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-# Flyway Version to Use (Check for latest version: https://documentation.red-gate.com/flyway/reference/usage/command-line.html)
+# Flyway Version to Use (Check for latest version: https://documentation.red-gate.com/flyway/reference/usage/command-line)
 if ($null -ne ${env:FLYWAY_VERSION}) {
   # Environment Variables - Use these if set as a variable - Target Database Connection Details
   Write-Output "Using Environment Variables for Flyway CLI Version Number"
@@ -35,13 +35,13 @@ if ($null -ne ${env:FLYWAY_PATH_LOCATION}) {
 }
 
 # Fetch the content of the web page
-Write-Output "Analysing https://documentation.red-gate.com/flyway/reference/usage/command-line.html for Latest Version Number"
+Write-Output "Analysing https://documentation.red-gate.com/flyway/reference/usage/command-line for Latest Version Number"
 # Check if $flywayVersion is 'latest' (case-insensitive)
 if ($flywayVersion -ieq "latest") {
     # Fetch the content of the web page
     try {
         # Define the URL to fetch and fetch page content
-        $url = "https://documentation.red-gate.com/flyway/reference/usage/command-line.html"
+        $url = "https://documentation.red-gate.com/flyway/reference/usage/command-line"
         $response = Invoke-WebRequest -Uri $url -UseBasicParsing
         $content = $response.Content
 

--- a/Scripts/Flyway_DownloadAndInstallCLI_Unix.sh
+++ b/Scripts/Flyway_DownloadAndInstallCLI_Unix.sh
@@ -22,7 +22,7 @@ get_installed_version() {
 # Function to get the latest version from the website
 get_latest_version_from_website() {
   # Fetch the webpage content
-  content=$(curl -s https://documentation.red-gate.com/fd/command-line-277579359.html)
+  content=$(curl -s https://documentation.red-gate.com/flyway/reference/usage/command-line.html)
 
   # Extract version number using regex
   latest_version=$(echo "$content" | grep -oP 'flyway-commandline-\K\d+\.\d+\.\d+(?=-windows-x64.zip)' | head -n 1)

--- a/Scripts/Flyway_DownloadAndInstallCLI_Unix.sh
+++ b/Scripts/Flyway_DownloadAndInstallCLI_Unix.sh
@@ -22,7 +22,7 @@ get_installed_version() {
 # Function to get the latest version from the website
 get_latest_version_from_website() {
   # Fetch the webpage content
-  content=$(curl -s https://documentation.red-gate.com/flyway/reference/usage/command-line.html)
+  content=$(curl -s https://documentation.red-gate.com/flyway/reference/usage/command-line)
 
   # Extract version number using regex
   latest_version=$(echo "$content" | grep -oP 'flyway-commandline-\K\d+\.\d+\.\d+(?=-windows-x64.zip)' | head -n 1)


### PR DESCRIPTION
The recent documentation move broke the flyway version evaluation of the 'Flyway_DownloadAndInstallCLI.ps1' & 'Flyway_DownloadAndInstallCLI_Unix.sh' scripts, meaning the download target couldn't be resolved.

A more robust version checker would be the preferable longer term solution, but this restores the original functionality.